### PR TITLE
Added a simple peg board

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,16 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link href="main.css" type="text/css" rel="stylesheet">
-    <script src="main.js"> </script>
-    <title>Document</title>
-</head>
-<body>
-    <h1> Hello world  from light bright let write some code </h1>
-    <h2> this is an h2 </h2>
-     <p> here is a pararaph </p>
-     
-</body>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link href="main.css" type="text/css" rel="stylesheet" />
+    <title>Light Bright</title>
+  </head>
+  <body>
+    <main>
+      <div id="peg-board"></div>
+    </main>
+    <script src="main.js"></script>
+  </body>
 </html>

--- a/main.css
+++ b/main.css
@@ -1,4 +1,40 @@
+:root {
+  --peg-board-background: #000000;
+  --peg-border-color: #131313;
+  --peg-default-color: #303030;
+  --peg-color-white: white;
+  --peg-color-red: red;
+  --peg-color-orange: orange;
+  --peg-color-yellow: yellow;
+  --peg-color-green: green;
+  --peg-color-blue: blue;
+  --peg-color-purple: purple;
+}
+
 body {
-    background-color: #88627e;
-   
+  background-color: var(--peg-board-background);
+}
+
+main {
+  min-width: 1000px;
+}
+
+.board-row {
+  display: flex;
+  flex-wrap: nowrap;
+  padding-bottom: 0.5em;
+}
+
+.board-row:nth-child(odd) {
+  padding-left: 0.5em;
+}
+
+.board-peg {
+  width: 0.6em;
+  height: 0.6em;
+  border-radius: 1em;
+  border: 1px solid var(--peg-border-color);
+  background-color: var(--peg-default-color);
+  user-select: none;
+  margin-right: 0.5em;
 }

--- a/main.js
+++ b/main.js
@@ -1,1 +1,21 @@
-alert("hello world  from lightbright main.js ");
+const addPegs = () => {
+  const numRows = 36;
+  const numColumns = 48;
+  const boardElem = document.getElementById("peg-board");
+  let rowElem = document.createElement("div");
+  rowElem.className = "board-row";
+  let rowInnerHtml = ``;
+
+  // Generate a row with numColumns number of pegs
+  for (var i = 0; i < numColumns; i++) {
+    rowInnerHtml += `<div class="board-peg">&nbsp;</div>`;
+  }
+  rowElem.innerHTML = rowInnerHtml;
+
+  // Add that row to the board numRows number of times
+  for (var i = 0; i < numRows; i++) {
+    boardElem.innerHTML += rowElem.outerHTML;
+  }
+};
+
+addPegs();


### PR DESCRIPTION
Resolves #2

### _PR #21 should be resolved first!_
 
# Description of Changes
Added a basic peg board to the site. Pegs are programmatically added from the master JS file instead of being hardcoded in the HTML file. This peg board design is based off of the XD files which are currently not hosted online.

Pegs and the board are currently a fixed size and don't scale to browser size. I figured that we could address those behaviors in another ticket.

Pegs are represented as `<div class="board-peg">&nbsp;</div>` elements. I figured that radio inputs would give us a shortcut to the intended "click" behavior, but since we'd have to introduce new functions for "click and drag" behavior that we'd have to overwrite default behavior anyway. I also expect that hundreds of input elements would add some processing overhead for the browser.

![image](https://user-images.githubusercontent.com/51807366/99922747-b4fdac80-2cf7-11eb-8b5b-b9fae5048008.png)
